### PR TITLE
Ghcr push workflow

### DIFF
--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -1,0 +1,50 @@
+name: Build and Push Docker Image to GHCR
+
+on:
+  push:
+    branches:
+      - master   #runs on every merge to master
+  pull_request:
+    branches:
+      - master  #also runs on PRs, but buidld-only
+
+  workflow_dispatch:   #lets you trigger this manually from Action tab
+
+jobs:
+  build-and-push:
+    name: Build and push to GHCR
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }} #automatically available, no secrets needed
+
+      # generates tags and labels from repo metadata
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804  #v5.7.0
+        with:
+          images: ghcr.io/${{ github.repository }}  
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}     #tag as 'latest' on master builds
+            type=sha,prefix=sha-     #tags with commit SHA
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  #v5.4.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}   #push only on master, skip PRs
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -1,14 +1,15 @@
 name: Build and Push Docker Image to GHCR
-
+ 
 on:
   push:
     branches:
-      - master   #runs on every merge to master
+      - master
+    tags:
+      - 'v*'            # push to registry only on version tags
   pull_request:
     branches:
-      - master  #also runs on PRs, but buidld-only
-
-  workflow_dispatch:   #lets you trigger this manually from Action tab
+      - master
+  workflow_dispatch:       # allows manual trigger from Action tab
 
 jobs:
   build-and-push:
@@ -33,18 +34,22 @@ jobs:
       # generates tags and labels from repo metadata
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804  #v5.7.0
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804  # v5.7.0
         with:
-          images: ghcr.io/${{ github.repository }}  
+          images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}     #tag as 'latest' on master builds
-            type=sha,prefix=sha-     #tags with commit SHA
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
+            type=sha,prefix=sha-  #tags with commit SHA
+
+  
       - name: Build and push Docker image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  #v5.4.0
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}   #push only on master, skip PRs
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}  # only push on tags
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -6,9 +6,6 @@ on:
       - master
     tags:
       - 'v*'            # push to registry only on version tags
-  pull_request:
-    branches:
-      - master
   workflow_dispatch:       # allows manual trigger from Action tab
 
 jobs:

--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -41,7 +41,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-
             type=sha,prefix=sha-  #tags with commit SHA
 
   


### PR DESCRIPTION
What this does:

- Builds on every push to master and every PR (to catch broken Dockerfiles early)
- Only pushes to GHCR on tagged releases - same pattern as the Python packages
- Tags the image with the version number and commit SHA so we can trace and roll back any build
- All third party actions are pinned to commit SHAs instead of floating tags
References:

- https://github.com/docker/login-action
- https://github.com/docker/metadata-action
- https://github.com/docker/build-push-action
- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry