### PR TITLE
Added layer caching

### DIFF
--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -49,3 +49,5 @@ jobs:
           push: ${{ startsWith(github.ref, 'refs/tags/') }}  # only push on tags
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:latest
+          cache-to: type=inline


### PR DESCRIPTION
Follow up to #14.

Added inline registry caching to the build step. With this, docker uses reused unchanged layers from the last pushed image, so only the changed parts gets rebuilt again.