### PR TITLE
Add read_packages permission for read-only access

### DIFF
--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -206,7 +206,8 @@ PERMISSIONS_LIST = [
     'interview_data',
     'log_user_in',
     'playground_control',
-    'template_parse'
+    'read_packages',
+    'template_parse' 
     ]
 
 CAN_CONVERT_WORD = can_convert_word_to_markdown()
@@ -21443,8 +21444,12 @@ def should_run_create(package_name):
 @csrf.exempt
 @cross_origin(origins='*', methods=['GET', 'POST', 'DELETE', 'HEAD'], automatic_options=True)
 def api_package():
-    if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages']):
-        return jsonify_with_status("Access denied.", 403)
+    if request.method == 'GET':
+        if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages', 'read_packages']):
+            return jsonify_with_status("Access denied.", 403)
+    else:
+        if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages']):
+            return jsonify_with_status("Access denied.", 403)
     if request.method == 'GET':
         package_list, package_auth = get_package_info()  # pylint: disable=unused-variable
         packages = []

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -21447,10 +21447,6 @@ def api_package():
     if request.method == 'GET':
         if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages', 'read_packages']):
             return jsonify_with_status("Access denied.", 403)
-    else:
-        if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages']):
-            return jsonify_with_status("Access denied.", 403)
-    if request.method == 'GET':
         package_list, package_auth = get_package_info()  # pylint: disable=unused-variable
         packages = []
         for package in package_list:
@@ -21467,6 +21463,8 @@ def api_package():
                 item['zip_file_number'] = package.package.upload
             packages.append(item)
         return jsonify(packages)
+    if not api_verify(roles=['admin', 'developer'], permissions=['manage_packages']):
+        return jsonify_with_status("Access denied.", 403)
     if request.method == 'DELETE':
         if not app.config['ALLOW_UPDATES']:
             return ('File not found', 404)


### PR DESCRIPTION
Closes [suffolklitlab/docassemble#6](https://github.com/SuffolkLITLab/security/issues/6)

Splits the /api/package permission check so GET only needs read_packages, while POST and DELETE still require manage_packages. Old keys with manage_packages still work for GET.

Also adds read_packages to PERMISSIONS_LIST.
