### PR TITLE
Switch back to root USER to run supervisor

### DIFF
--- a/Docker/Dockerfile.preinstall
+++ b/Docker/Dockerfile.preinstall
@@ -6,3 +6,7 @@ USER www-data
 RUN bash -c \
 "source /usr/share/docassemble/local3.12/bin/activate \
 && pip install --no-cache-dir -r /tmp/requirements-preinstall.txt"
+
+USER root
+
+CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]


### PR DESCRIPTION
`USER www-data` stays enabled by default, and supervisor can't run with that user.