### PR TITLE
Fix websockets not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jhpyle/docassemble-os
+FROM jhpyle/docassemble-os:1.0.28
 USER root
 
 COPY ./Docker/nginx.conf /tmp/docassemble/Docker/nginx.conf

--- a/docassemble_webapp/pyproject.toml
+++ b/docassemble_webapp/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
   "flask-cors==6.0.2",
   "Flask-Login==0.6.3",
   "Flask-Mail==0.10.0",
-  "Flask-SocketIO==5.6.0",
+  "Flask-SocketIO==5.6.1",
   "Flask-SQLAlchemy==3.1.1",
   "Flask-WTF==1.2.2",
   "fonttools==4.61.1",


### PR DESCRIPTION
Flask 3.1.2 and up needs Flaks-SocketIO 5.6.1 for WebSocket stuff to work correctly.

Example of the error you'll see:

```
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/flask_socketio/__init__.py", line 815, in _handle_event
    ctx.session = session_obj
    ^^^^^^^^^^^
AttributeError: property 'session' of 'RequestContext' object has no setter
```

Noted at: https://github.com/miguelgrinberg/Flask-SocketIO/issues/2152

Tested by starting a local docassemble container, changing the `url root:` in the config to be `url root: http://localhost`, and opening an interview in one tab, and the "Monitor" page in another tab. You should see an active session. 