### PR TITLE
Fix nginx postrotate

### DIFF
--- a/Docker/nginx.logrotate
+++ b/Docker/nginx.logrotate
@@ -13,7 +13,7 @@
                 fi \
         endscript
         postrotate
-	        if /etc/init.d/nginx status > /dev/null ; then \
+	        if /etc/init.d/nginx-debug status > /dev/null ; then \
                         /usr/share/docassemble/webapp/restart-nginx.sh ; \
                 fi
         endscript


### PR DESCRIPTION
The postrotate action of nginx's lograte wasn't being run, because there isn't a `/etc/init.d/nginx` anymore (confirmed it's because we've updated nginx in e9e926ca2ce1634511197e10d5481f21f81e2776, so this shouldn't be pushed upstream). Logrotate would still rename the logs, but nginx would continue writing to the renamed file, thus continuing to use access.log.1.

Changing it to `nginx-debug` fixes the issue.

Idea from https://serverfault.com/questions/823725/logrotate-not-writing-logs-to-correct-file