### PR TITLE
Remove maxsize from docassemble logrotate config

### DIFF
--- a/Docker/docassemble.logrotate
+++ b/Docker/docassemble.logrotate
@@ -11,7 +11,6 @@
         su www-data www-data
 	create 600 www-data www-data
 	rotate 7
-	maxsize 5M
 	daily
 	missingok
 	notifempty


### PR DESCRIPTION
maxsize rotates a log as soon as it crosses the size threshold, regardless of the daily schedule - that's why we were seeing uwsgi restarts (and the downtime that comes with it) at random times during the day instead of the expected rotation. Since these logs stay well under ~50MB even on a daily cycle, there's no real need for the size-based trigger.

Left the /var/mail/mail stanza's maxsize untouched (it has no postrotate script), so it doesn't cause restarts
Closes #68