### PR TITLE
Add useful info to error emails

### DIFF
--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -9031,7 +9031,13 @@ class Interview:
                         follow_mc = True
                         missingVariable = extract_missing_name(the_exception)
                     variables_sought.add(missingVariable)
-                    question_result = self.askfor(missingVariable, user_dict, old_user_dict, interview_status, seeking=interview_status.seeking, follow_mc=follow_mc, seeking_question=seeking_question)
+                    try:
+                        question_result = self.askfor(missingVariable, user_dict, old_user_dict, interview_status, seeking=interview_status.seeking, follow_mc=follow_mc, seeking_question=seeking_question)
+                    except DAErrorMissingVariable as _dmv_exc:
+                        _asking_question = getattr(docassemble.base.functions.this_thread, 'current_question', None)
+                        if _asking_question is not None:
+                            _dmv_exc.da_asking_question = getattr(_asking_question, 'name', None) or str(_asking_question)
+                        raise
                     if question_result['type'] in ('continue', 're_run'):
                         continue
                     if question_result['type'] == 'refresh':

--- a/docassemble_base/docassemble/base/parse.py
+++ b/docassemble_base/docassemble/base/parse.py
@@ -2084,15 +2084,19 @@ class Question:
                 return "\nIn file " + str(self.from_source.path) + " from package " + str(self.package) + ":\n\n" + repr(data)
             return repr(data)
 
-    def id_debug(self, data):
+    def id_debug(self, data=None):
         """One liner info about a YAML block. Used in `compile` for later error reporting."""
+        if data is None:
+            the_id = getattr(self, 'id', None)
+        else:
+            the_id = data.get('id')
         if hasattr(self, 'from_source'):
             if isinstance(self.line_number, int):
                 return f"{self.from_source.path}, block on line {self.line_number}"
-            return f"{self.from_source.path}, id:{data.get('id')}"
+            return f"{self.from_source.path}, id:{the_id}"
         if hasattr(self, 'package'):
-            return f"{self.package}, id:{data.get('id')}"
-        return data.get("id") or ""
+            return f"{self.package}, id:{the_id}"
+        return the_id or ""
 
     def __init__(self, orig_data, caller, **kwargs):
         if not isinstance(orig_data, dict):
@@ -9036,7 +9040,7 @@ class Interview:
                     except DAErrorMissingVariable as _dmv_exc:
                         _asking_question = getattr(docassemble.base.functions.this_thread, 'current_question', None)
                         if _asking_question is not None:
-                            _dmv_exc.da_asking_question = getattr(_asking_question, 'name', None) or str(_asking_question)
+                            _dmv_exc.da_asking_question = _asking_question.id_debug()
                         raise
                     if question_result['type'] in ('continue', 're_run'):
                         continue

--- a/docassemble_webapp/docassemble/webapp/cron.py
+++ b/docassemble_webapp/docassemble/webapp/cron.py
@@ -285,6 +285,8 @@ def run_cron(the_cron_type):
                                         error_trace = str(err.traceback)
                                         if hasattr(err, 'da_line_with_error'):
                                             error_trace += "\nIn line: " + str(err.da_line_with_error)
+                                        if hasattr(err, 'da_asking_question'):
+                                            error_trace += "\nNeeded by question: " + str(err.da_asking_question)
                                     else:
                                         error_trace = None
                                     error_notification(err, trace=error_trace)

--- a/docassemble_webapp/docassemble/webapp/server.py
+++ b/docassemble_webapp/docassemble/webapp/server.py
@@ -15769,6 +15769,8 @@ def server_error(the_error):
         logmessage(str(the_error))
     elif isinstance(the_error, (DAError, DANotFoundError, DAInvalidFilename)):
         errmess = str(the_error)
+        if hasattr(the_error, 'da_asking_question'):
+            errmess += "\nNeeded by question: " + str(the_error.da_asking_question)
         the_trace = None
         logmessage(errmess)
     elif isinstance(the_error, TemplateError):
@@ -23899,7 +23901,25 @@ def error_notification(err, message=None, history=None, trace=None, referer=None
         email_address = current_user.email
     except:
         email_address = None
+    session_id = None
+    real_url = None
+    temp_user_id = None
+    try:
+        current_info = docassemble.base.functions.this_thread.current_info
+        session_id = current_info.get('session')
+        real_url = current_info.get('url')
+        user_info_dict = current_info.get('user') or {}
+        if str(user_info_dict.get('the_user_id', '')).startswith('t'):
+            temp_user_id = user_info_dict.get('theid')
+    except:
+        pass
+    if email_address is None and temp_user_id is not None:
+        email_address = "temp user " + str(temp_user_id)
     if the_request:
+        try:
+            real_url = str(the_request.url)
+        except:
+            pass
         try:
             referer = str(the_request.referrer)
         except:
@@ -23946,6 +23966,12 @@ def error_notification(err, message=None, history=None, trace=None, referer=None
             if history is not None:
                 body += "\n\n" + BeautifulSoup(history, "html.parser").get_text('\n')
                 html += history
+            if session_id is not None:
+                body += "\n\nThe session ID was " + str(session_id)
+                html += "<p>The session ID was " + str(session_id) + "</p>"
+            if real_url is not None:
+                body += "\n\nThe URL was " + str(real_url)
+                html += "<p>The URL was " + str(real_url) + "</p>"
             if referer is not None and referer != 'None':
                 body += "\n\nThe referer URL was " + str(referer)
                 html += "<p>The referer URL was " + str(referer) + "</p>"

--- a/docassemble_webapp/docassemble/webapp/worker_common.py
+++ b/docassemble_webapp/docassemble/webapp/worker_common.py
@@ -120,6 +120,8 @@ def process_error(interview, session_code, yaml_filename, secret, user_info, url
             error_trace = str(e.traceback)
             if hasattr(e, 'da_line_with_error'):
                 error_trace += "\nIn line: " + str(e.da_line_with_error)
+            if hasattr(e, 'da_asking_question'):
+                error_trace += "\nNeeded by question: " + str(e.da_asking_question)
         else:
             error_trace = None
         worker_controller.error_notification(e, message=error_message, trace=error_trace)

--- a/docassemble_webapp/docassemble/webapp/worker_tasks.py
+++ b/docassemble_webapp/docassemble/webapp/worker_tasks.py
@@ -1099,6 +1099,8 @@ def background_action(yaml_filename, user_info, session_code, secret, url, url_r
                     error_trace = ''.join(traceback.format_tb(e.__traceback__))
                     if hasattr(e, 'da_line_with_error'):
                         error_trace += "\nIn line: " + str(e.da_line_with_error)
+                    if hasattr(e, 'da_asking_question'):
+                        error_trace += "\nNeeded by question: " + str(e.da_asking_question)
                 else:
                     error_trace = None
                 variables = list(reversed(list(worker_controller.functions.this_thread.current_variable)))
@@ -1160,6 +1162,8 @@ def background_action(yaml_filename, user_info, session_code, secret, url, url_r
                         error_trace = str(e.traceback)
                         if hasattr(e, 'da_line_with_error'):
                             error_trace += "\nIn line: " + str(e.da_line_with_error)
+                        if hasattr(e, 'da_asking_question'):
+                            error_trace += "\nNeeded by question: " + str(e.da_asking_question)
                     else:
                         error_trace = None
                     variables = list(reversed(list(worker_controller.functions.this_thread.current_variable)))


### PR DESCRIPTION
Addresses #70 

Adds missing context to Docassemble's error notification emails (session ID, full URL, temp user ID, and which question needed a variable for DAErrorMissingVariable errors).

Triggered few real errors locally through normal web path and the background-action (worker) path, confirming each field shows up correctly in the actual email content.
